### PR TITLE
Validate close column in analyze_csv

### DIFF
--- a/scripts/fourier_utils.py
+++ b/scripts/fourier_utils.py
@@ -70,8 +70,11 @@ def suggest_ichimoku_params(P: float, lfp: float) -> Dict[str, float]:
 
 def analyze_csv(path: Path, timeframe_hours: float = 2.0, window_days: int = 180) -> Dict[str, float]:
     df = pd.read_csv(path)
-    # Expect columns: timestamp, open, high, low, close, volume (flexible)
-    close = df[df.columns[-2]].to_numpy(dtype=float) if 'close' not in df.columns else df['close'].to_numpy(dtype=float)
+    # Expect a column containing close prices (case-insensitive search).
+    close_col = next((c for c in df.columns if "close" in c.lower()), None)
+    if close_col is None:
+        raise ValueError(f"No close column found in {path}")
+    close = df[close_col].to_numpy(dtype=float)
     # Use last N days
     bars_per_day = int(round(24.0 / timeframe_hours))
     n = max(256, window_days * bars_per_day)

--- a/test_fourier_utils.py
+++ b/test_fourier_utils.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pytest
+from pathlib import Path
+
+from scripts.fourier_utils import analyze_csv
+
+
+def _make_csv(df: pd.DataFrame, tmp_path: Path) -> Path:
+    path = tmp_path / "data.csv"
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_analyze_csv_uses_close_column(tmp_path: Path) -> None:
+    """analyze_csv should locate the close column without assuming its position."""
+    data = {
+        "timestamp": range(300),
+        "open": [1.0] * 300,
+        "high": [1.0] * 300,
+        "low": [1.0] * 300,
+        "Close": [1.0] * 300,  # Mixed case to test case-insensitivity
+        "volume": [1.0] * 300,
+    }
+    csv_path = _make_csv(pd.DataFrame(data), tmp_path)
+    stats = analyze_csv(csv_path, timeframe_hours=2.0, window_days=1)
+    assert "P_bars" in stats
+
+
+def test_analyze_csv_raises_without_close(tmp_path: Path) -> None:
+    df = pd.DataFrame({"open": [1, 2], "volume": [10, 20]})
+    csv_path = _make_csv(df, tmp_path)
+    with pytest.raises(ValueError, match="No close column"):
+        analyze_csv(csv_path)
+


### PR DESCRIPTION
## Summary
- Search for close price column by name rather than position in `analyze_csv`, raising an explicit error if absent
- Add tests verifying case-insensitive close column detection and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae81211f248331bcafde1db7762e90