### PR TITLE
Remove obsolete PHASE_STATS_ALL reference

### DIFF
--- a/scripts/fourier_phase_analysis.py
+++ b/scripts/fourier_phase_analysis.py
@@ -12,10 +12,9 @@ Steps:
 - Calibrate LFP/LFP_vol gating thresholds
 
 Outputs:
-- outputs/fourier/phase/PHASE_STATS_<symbol>_<tf>.csv
-- outputs/fourier/phase/PHASE_STATS_ALL.csv
-- outputs/fourier/phase/*.png (bar plots)
-- outputs/fourier/phase/SCHEDULER_FOURIER_<symbol>_<tf>.json
+- outputs/fourier/phase/<symbol>_<tf>/PHASE_STATS_<symbol>_<tf>.csv
+- outputs/fourier/phase/<symbol>_<tf>/*.png (bar plots)
+- outputs/fourier/phase/<symbol>_<tf>/SCHEDULER_FOURIER_<symbol>_<tf>.json
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- drop outdated PHASE_STATS_ALL.csv output from fourier_phase_analysis docstring
- document actual per-symbol/timeframe output locations

## Testing
- `python scripts/fourier_phase_analysis.py --symbol BTC_USDT --timeframe 2h`
- `find outputs/fourier/phase -maxdepth 1 -type f -name 'PHASE_STATS_ALL.csv'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae810e67308331bcbcff0877c2cc01