### PR TITLE
Add Ichimoku phase presets and optional snapshot features

### DIFF
--- a/docs/PHASE_ICHIMOKU_SETTINGS.md
+++ b/docs/PHASE_ICHIMOKU_SETTINGS.md
@@ -1,0 +1,25 @@
+# Phase ↔ Ichimoku presets
+
+Ce fichier centralise les réglages **Ichimoku** utilisés pour chaque phase
+du moteur halving.
+
+## Contenu
+- `scripts/phase_ichimoku_settings.py` : dictionnaire `PHASE_ICHIMOKU`
+  et fonction `ichimoku_params_for_phase()` pour récupérer
+  `(tenkan, kijun, senkou_b)`.
+- `scripts/phase_aware_module.py` : paramètre `use_ichimoku=True` dans
+  `phase_snapshot()` calcule `M` à partir de Tenkan/Kijun et ajoute les
+  colonnes `tenkan`, `kijun`, `cloud_top`, `cloud_bot` aux features.
+
+## Exemple
+```python
+from scripts.phase_aware_module import phase_snapshot
+from scripts.phase_ichimoku_settings import ichimoku_params_for_phase
+
+feats = phase_snapshot(df, use_ichimoku=True)
+phase = feats.iloc[-1]["phase"]
+params = ichimoku_params_for_phase(phase)
+```
+
+La configuration est isolée afin de faciliter les ajustements ultérieurs
+sans modifier le code principal.

--- a/scripts/phase_ichimoku_settings.py
+++ b/scripts/phase_ichimoku_settings.py
@@ -1,0 +1,28 @@
+"""Per-phase Ichimoku presets.
+
+This small helper isolates the mapping between market phases and
+preferred Ichimoku lengths so it can be tuned without touching the main
+module. Parameters are expressed in bars.
+"""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+PHASE_ICHIMOKU: Dict[str, Tuple[int, int, int]] = {
+    "accumulation": (6, 26, 52),
+    "expansion": (6, 43, 100),
+    "euphoria": (6, 55, 120),
+    "distribution": (9, 65, 120),
+    "bear": (6, 26, 100),
+}
+
+
+def ichimoku_params_for_phase(
+    phase: str, mapping: Dict[str, Tuple[int, int, int]] = PHASE_ICHIMOKU
+) -> Tuple[int, int, int]:
+    """Return (tenkan, kijun, senkou_b) for the given ``phase``.
+
+    If the phase is unknown, fall back to the classic 9-26-52 tuple.
+    """
+
+    return mapping.get(phase, (9, 26, 52))


### PR DESCRIPTION
## Summary
- allow `phase_snapshot` to compute momentum from Ichimoku lines
- provide per-phase Ichimoku presets in a dedicated helper
- document how to adjust and use the presets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3e94a071c8331af8311fcb6d7bf33