### PR TITLE
Add synthetic Elliott wave price generator

### DIFF
--- a/creation_de_la_cle/README.md
+++ b/creation_de_la_cle/README.md
@@ -1,0 +1,21 @@
+# Création de la clé
+
+Ce dossier contient une description succincte de la théorie des vagues d'Elliott et un script Python permettant de générer des séries de prix synthétiques respectant cette structure.
+
+## Théorie des vagues d'Elliott
+
+Dans son cycle de base, la théorie d'Elliott décrit huit mouvements successifs : cinq vagues motrices (impulsion) suivies de trois vagues correctives.
+
+```
+1↑ 2↓ 3↑ 4↓ 5↑ → A↓ B↑ C↓
+```
+
+### Règles essentielles
+
+- La vague 3 n'est jamais la plus courte des vagues impulsives (1, 3, 5).
+- La vague 2 ne retrace jamais sous le point de départ de la vague 1.
+- La vague 4 n'empiète pas sur le territoire de la vague 1 (sauf cas de diagonales).
+- La structure est fractale : chaque vague peut se décomposer en sous-vagues.
+
+Les corrections peuvent prendre différentes formes (zigzag 5-3-5, flat 3-3-5, triangle 3-3-3-3-3, ou combinaisons complexes W-X-Y...).
+

--- a/creation_de_la_cle/generateur_elliott.py
+++ b/creation_de_la_cle/generateur_elliott.py
@@ -1,0 +1,52 @@
+"""Génère des séries de prix synthétiques respectant la structure de base des vagues d'Elliott."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def generate_elliott_wave_series(start: float = 100.0, scale: float = 10.0, cycles: int = 1, seed: int | None = None) -> np.ndarray:
+    """Génère une série de prix suivant un motif 1-2-3-4-5-A-B-C.
+
+    Parameters
+    ----------
+    start: float
+        Prix initial.
+    scale: float
+        Amplitude de base utilisée pour dimensionner les vagues.
+    cycles: int
+        Nombre de cycles complets à générer.
+    seed: int | None
+        Graine pour la reproductibilité.
+    """
+    rng = np.random.default_rng(seed)
+    series = []
+    price = start
+
+    for _ in range(cycles):
+        w1 = scale * rng.uniform(0.5, 1.0)
+        w3 = scale * rng.uniform(max(w1 / scale, 1.0), 2.0)  # vague 3 >= vague 1
+        w5 = scale * rng.uniform(0.5, w3 / scale * 0.9)
+
+        w2 = -scale * rng.uniform(0.3, min(w1 / scale * 0.9, 0.8))
+        if price + w1 + w2 <= price:
+            w2 = -(w1 * 0.8)  # assure que la vague 2 ne dépasse pas le départ
+
+        w4 = -scale * rng.uniform(0.3, min(w3 / scale * 0.6, 0.8))
+        if price + w1 + w2 + w3 + w4 <= price + w1:
+            w4 = -( (price + w1 + w2 + w3) - (price + w1) ) * 0.9  # pas d'empiètement sur vague 1
+
+        wA = -scale * rng.uniform(0.4, w5 / scale + 0.3)
+        wB = scale * rng.uniform(0.2, 0.6)
+        wC = -scale * rng.uniform(max(0.6, abs(wA) / scale), abs(wA) / scale + 0.5)
+
+        increments = [w1, w2, w3, w4, w5, wA, wB, wC]
+        for inc in increments:
+            price += inc
+            series.append(price)
+
+    return np.array(series)
+
+
+if __name__ == "__main__":
+    data = generate_elliott_wave_series(cycles=2, seed=42)
+    print(data)


### PR DESCRIPTION
## Summary
- add `creation_de_la_cle` module with Elliott Wave theory notes
- implement `generate_elliott_wave_series` to build synthetic price data respecting Elliott wave structure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba91ad4cb08331aa779e6bdfcdbe4c