### PR TITLE
Add HMM regime module with fallback and tests

### DIFF
--- a/src/regime_hmm.py
+++ b/src/regime_hmm.py
@@ -1,0 +1,400 @@
+"""Utility functions for fitting and applying HMM-based regime filters.
+
+The module implements three main entry points:
+
+```
+fit_hmm(train_features, K=[2, 3, 4], seed=None)
+predict_hmm(model, features)
+apply_hmm(train_df, test_df, cfg)
+```
+
+`fit_hmm` trains Gaussian HMM candidates and rejects configurations where
+some regimes are too rare when measured both in cumulative duration and in the
+number of trades. `predict_hmm` simply decodes a feature matrix with a frozen
+model, while `apply_hmm` orchestrates the workflow: scale the training features,
+fit the best model and decode only the out-of-sample rows. If every candidate is
+rejected, a Fourier based fallback (`rules_fourier`) is used instead. The
+functions are written to avoid lookahead: all parameters (scalers, quantiles,
+model weights) are derived from the in-sample portion and then frozen before
+being applied to the test set.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+from hmmlearn.hmm import GaussianHMM
+
+__all__ = [
+    "HMMFitResult",
+    "fit_hmm",
+    "predict_hmm",
+    "apply_hmm",
+    "rules_fourier",
+]
+
+
+@dataclass(frozen=True)
+class HMMFitResult:
+    """Bundle returned by :func:`fit_hmm`.
+
+    Attributes
+    ----------
+    model:
+        The GaussianHMM instance selected according to the BIC criterion.
+    K:
+        Number of hidden states used by ``model``.
+    bic:
+        Bayesian information criterion computed on the training window.
+    state_summary:
+        DataFrame indexed by state id with coverage statistics
+        (count, cumulative duration/trades and the associated fractions).
+    train_states:
+        Hidden state sequence decoded on the training window. It is provided for
+        diagnostics only and is never used for out-of-sample predictions in
+        :func:`apply_hmm`.
+    """
+
+    model: GaussianHMM
+    K: int
+    bic: float
+    state_summary: pd.DataFrame
+    train_states: pd.Series
+
+
+def _as_dataframe(data: pd.DataFrame | np.ndarray | Sequence[Sequence[float]]) -> pd.DataFrame:
+    """Return *data* as a numeric :class:`~pandas.DataFrame`.
+
+    Non numeric columns are dropped. A :class:`ValueError` is raised when no
+    numeric feature is left after sanitisation.
+    """
+
+    if isinstance(data, pd.DataFrame):
+        df = data.copy()
+    else:
+        df = pd.DataFrame(data)
+    numeric_df = df.select_dtypes(include=[np.number])
+    if numeric_df.shape[1] == 0:
+        raise ValueError("train_features must contain at least one numeric column")
+    return numeric_df
+
+
+def _prepare_measure(series: Optional[Iterable[float]], index: pd.Index, default: float) -> pd.Series:
+    """Convert ``series`` to a float :class:`~pandas.Series` aligned on *index*.
+
+    When ``series`` is *None*, a constant series filled with ``default`` is
+    returned. The helper ensures that no negative entries slip into the
+    downstream computations.
+    """
+
+    if series is None:
+        values = np.full(len(index), float(default), dtype=float)
+        return pd.Series(values, index=index, dtype=float)
+    series_pd = pd.Series(series, index=index, dtype=float)
+    if (series_pd < 0).any():
+        raise ValueError("Duration/trade count series must be non-negative")
+    return series_pd
+
+
+def _bic(model: GaussianHMM, X: np.ndarray) -> float:
+    """Compute the Bayesian information criterion for ``model`` on ``X``."""
+
+    n, n_features = X.shape
+    ll = float(model.score(X))
+    # Number of free parameters: means + diag covariances + transitions + startprob
+    params = model.n_components * n_features  # means
+    params += model.n_components * n_features  # diag covariances
+    params += model.n_components * (model.n_components - 1)  # transition matrix
+    params += (model.n_components - 1)  # start probabilities
+    return params * np.log(max(n, 1)) - 2.0 * ll
+
+
+def fit_hmm(
+    train_features: pd.DataFrame | np.ndarray | Sequence[Sequence[float]],
+    K: Sequence[int] | None = (2, 3, 4),
+    seed: Optional[int] = None,
+    *,
+    durations: Optional[Iterable[float]] = None,
+    trade_counts: Optional[Iterable[float]] = None,
+    min_duration_frac: float = 0.05,
+    min_trade_frac: float = 0.05,
+    min_trades: float = 5.0,
+    min_obs: int = 15,
+) -> HMMFitResult:
+    """Estimate an HMM on the *train_features* matrix.
+
+    Parameters
+    ----------
+    train_features:
+        Feature matrix used for the fit. It can be a :class:`~pandas.DataFrame`,
+        a two-dimensional :class:`numpy.ndarray` or any sequence convertible to a
+        DataFrame. The function drops non-numeric columns.
+    K:
+        Iterable of candidate numbers of regimes. Candidates producing *rare*
+        states are skipped. A state is marked as rare when its cumulative
+        duration or the number of trades represents less than the respective
+        fraction thresholds or when it contains fewer than ``min_obs`` samples.
+    seed:
+        Random seed forwarded to :class:`hmmlearn.hmm.GaussianHMM` for
+        reproducibility.
+    durations, trade_counts:
+        Optional iterables aligned with ``train_features``. They are used to
+        measure the coverage of each state. When omitted, unit weights are
+        assumed.
+    min_duration_frac, min_trade_frac:
+        Fractional coverage thresholds (in [0, 1]). If a state represents less
+        than the threshold of the total duration/trade volume, the model is
+        rejected.
+    min_trades:
+        Minimal absolute number of trades required for each state. It acts as a
+        safeguard when the total number of trades is small.
+    min_obs:
+        Minimal number of samples assigned to each hidden state.
+
+    Returns
+    -------
+    HMMFitResult
+        Selected model and diagnostics.
+
+    Raises
+    ------
+    ValueError
+        If every candidate in ``K`` is rejected because of rare states or
+        because the input matrix is empty.
+    """
+
+    features = _as_dataframe(train_features)
+    if features.empty:
+        raise ValueError("Cannot fit an HMM on an empty feature matrix")
+
+    index = features.index if isinstance(train_features, pd.DataFrame) else pd.RangeIndex(len(features))
+    durations_series = _prepare_measure(durations, index, default=1.0)
+    trades_series = _prepare_measure(trade_counts, index, default=1.0)
+
+    X = features.to_numpy(dtype=float)
+    valid_results: List[HMMFitResult] = []
+    seen_k = [] if K is None else list(dict.fromkeys(int(k) for k in K if int(k) > 0))
+    if not seen_k:
+        seen_k = [2, 3, 4]
+
+    for k in seen_k:
+        model = GaussianHMM(
+            n_components=k,
+            covariance_type="diag",
+            n_iter=500,
+            tol=1e-4,
+            random_state=seed,
+        )
+        model.fit(X)
+        states = pd.Series(model.predict(X), index=index, name="state")
+        counts = states.value_counts().sort_index()
+        duration_by_state = durations_series.groupby(states).sum().sort_index()
+        trade_by_state = trades_series.groupby(states).sum().sort_index()
+        duration_frac = duration_by_state / duration_by_state.sum() if duration_by_state.sum() else duration_by_state * 0.0
+        trade_frac = trade_by_state / trade_by_state.sum() if trade_by_state.sum() else trade_by_state * 0.0
+
+        rare_mask = (
+            (duration_frac < min_duration_frac)
+            | (trade_frac < min_trade_frac)
+            | (trade_by_state < min_trades)
+            | (counts < min_obs)
+        )
+        if bool(rare_mask.any()):
+            continue
+
+        summary = pd.DataFrame(
+            {
+                "count": counts,
+                "duration": duration_by_state,
+                "duration_frac": duration_frac,
+                "trades": trade_by_state,
+                "trade_frac": trade_frac,
+            }
+        )
+        result = HMMFitResult(
+            model=model,
+            K=k,
+            bic=_bic(model, X),
+            state_summary=summary,
+            train_states=states,
+        )
+        valid_results.append(result)
+
+    if not valid_results:
+        raise ValueError("All HMM candidates were rejected due to rare states")
+
+    best = min(valid_results, key=lambda res: (res.bic, res.K))
+    return best
+
+
+def predict_hmm(model: GaussianHMM, features: pd.DataFrame | np.ndarray) -> pd.Series:
+    """Decode hidden states for ``features`` using a frozen ``model``.
+
+    Parameters
+    ----------
+    model:
+        Previously fitted :class:`hmmlearn.hmm.GaussianHMM`.
+    features:
+        Feature matrix matching the training layout. It must already be scaled
+        with the statistics computed on the training window.
+
+    Returns
+    -------
+    pandas.Series
+        Sequence of hidden states aligned with the rows of ``features``. The
+        function never mutates or refits ``model`` which guarantees that the
+        parameters stay frozen when the series is applied out-of-sample.
+    """
+
+    df = _as_dataframe(features)
+    X = df.to_numpy(dtype=float)
+    states = model.predict(X)
+    return pd.Series(states, index=df.index, name="state")
+
+
+def rules_fourier(train_df: pd.DataFrame, test_df: pd.DataFrame, cfg: Dict[str, object]) -> pd.Series:
+    """Fallback regime classifier based on Fourier quantiles.
+
+    The rule maps each out-of-sample row to ``{"trend", "range", "transition"}``
+    according to the quantiles (defaults to 25/75%) of ``P1`` and ``LFP``
+    measured on the training window. Missing Fourier columns trigger a
+    :class:`ValueError` to make the failure explicit.
+    """
+
+    fourier_cols = cfg.get("fourier_cols") if isinstance(cfg, dict) else None
+    if not isinstance(fourier_cols, dict):
+        raise ValueError("cfg must define a 'fourier_cols' mapping for fallback")
+    p1_col = fourier_cols.get("P1")
+    lfp_col = fourier_cols.get("LFP")
+    if p1_col is None or lfp_col is None:
+        raise ValueError("fourier_cols must contain 'P1' and 'LFP' keys")
+    if p1_col not in train_df or lfp_col not in train_df:
+        raise ValueError("Training dataframe is missing required Fourier columns")
+    if p1_col not in test_df or lfp_col not in test_df:
+        raise ValueError("Test dataframe is missing required Fourier columns")
+
+    quantiles = cfg.get("quantiles", (0.25, 0.75)) if isinstance(cfg, dict) else (0.25, 0.75)
+    if not isinstance(quantiles, (list, tuple)) or len(quantiles) != 2:
+        raise ValueError("quantiles must be a length-2 tuple/list")
+    q_low, q_high = float(min(quantiles)), float(max(quantiles))
+
+    p1_train = train_df[p1_col].astype(float)
+    lfp_train = train_df[lfp_col].astype(float)
+    p1_low, p1_high = p1_train.quantile(q_low), p1_train.quantile(q_high)
+    lfp_low, lfp_high = lfp_train.quantile(q_low), lfp_train.quantile(q_high)
+
+    p1_test = test_df[p1_col].astype(float)
+    lfp_test = test_df[lfp_col].astype(float)
+    unknown_mask = p1_test.isna() | lfp_test.isna()
+    states = np.full(len(test_df), "transition", dtype=object)
+    states[(lfp_test >= lfp_high) & (p1_test >= p1_high)] = "trend"
+    states[(lfp_test <= lfp_low) | (p1_test <= p1_low)] = "range"
+    states[unknown_mask] = "unknown"
+    return pd.Series(states, index=test_df.index, name="regime")
+
+
+def apply_hmm(train_df: pd.DataFrame, test_df: pd.DataFrame, cfg: Dict[str, object]) -> Dict[str, object]:
+    """Fit an HMM on ``train_df`` and decode the frozen model on ``test_df``.
+
+    Parameters
+    ----------
+    train_df, test_df:
+        DataFrames split chronologically. Only ``train_df`` is used to fit the
+        scaling statistics and the HMM parameters. ``test_df`` is never leaked
+        into the calibration step which prevents lookahead bias.
+    cfg:
+        Dictionary describing the configuration. The most relevant keys are:
+
+        - ``feature_cols`` (list): feature names used by the HMM.
+        - ``duration_col`` / ``trade_count_col`` (str, optional): cumulative
+          measures used to reject rare states.
+        - ``K`` (iterable of int): candidate number of regimes.
+        - ``seed`` (int, optional): random seed for reproducibility.
+        - ``min_duration_frac`` / ``min_trade_frac`` / ``min_trades`` /
+          ``min_obs``: thresholds forwarded to :func:`fit_hmm`.
+        - ``fourier_cols`` and ``quantiles``: parameters for
+          :func:`rules_fourier` when the HMM is rejected.
+        - ``return_train_states`` (bool): whether to include the decoded train
+          sequence for diagnostics. It defaults to ``False`` to emphasise that
+          the production workflow should only consume the out-of-sample states.
+
+    Returns
+    -------
+    dict
+        Always contains ``oos_states`` (out-of-sample sequence as a
+        :class:`pandas.Series`) and ``scaler`` (median/MAD statistics). When the
+        HMM succeeds, ``model``, ``train_summary`` and metadata (``K``, ``bic``)
+        are provided. Otherwise, ``model`` is ``None`` and ``fallback`` equals
+        ``"rules_fourier"``. In both cases the predictions are generated using a
+        model whose parameters are frozen on the training slice only.
+    """
+
+    if not isinstance(train_df, pd.DataFrame) or not isinstance(test_df, pd.DataFrame):
+        raise TypeError("train_df and test_df must be pandas DataFrames")
+    if train_df.empty or test_df.empty:
+        raise ValueError("Both train_df and test_df must be non-empty")
+
+    feature_cols = cfg.get("feature_cols") if isinstance(cfg, dict) else None
+    if not isinstance(feature_cols, (list, tuple)) or not feature_cols:
+        raise ValueError("cfg must define a non-empty 'feature_cols' list")
+    missing_train = [col for col in feature_cols if col not in train_df]
+    missing_test = [col for col in feature_cols if col not in test_df]
+    if missing_train:
+        raise ValueError(f"train_df is missing feature columns: {missing_train}")
+    if missing_test:
+        raise ValueError(f"test_df is missing feature columns: {missing_test}")
+
+    train_features = train_df[feature_cols].astype(float)
+    test_features = test_df[feature_cols].astype(float)
+
+    median = train_features.median()
+    mad = (train_features - median).abs().median()
+    mad = mad.replace(0.0, 1.0)
+    train_scaled = (train_features - median) / mad
+    test_scaled = (test_features - median) / mad
+
+    duration_col = cfg.get("duration_col") if isinstance(cfg, dict) else None
+    trade_col = cfg.get("trade_count_col") if isinstance(cfg, dict) else None
+    durations = train_df[duration_col] if duration_col in train_df else None
+    trades = train_df[trade_col] if trade_col in train_df else None
+
+    fit_kwargs = dict(
+        durations=durations,
+        trade_counts=trades,
+        min_duration_frac=cfg.get("min_duration_frac", 0.05),
+        min_trade_frac=cfg.get("min_trade_frac", 0.05),
+        min_trades=cfg.get("min_trades", 5.0),
+        min_obs=cfg.get("min_obs", 15),
+    )
+
+    try:
+        fit_result = fit_hmm(
+            train_scaled,
+            K=cfg.get("K", (2, 3, 4)),
+            seed=cfg.get("seed"),
+            **fit_kwargs,
+        )
+        oos_states = predict_hmm(fit_result.model, test_scaled)
+        result: Dict[str, object] = {
+            "model": fit_result.model,
+            "oos_states": oos_states,
+            "train_summary": fit_result.state_summary,
+            "scaler": {"median": median, "mad": mad},
+            "K": fit_result.K,
+            "bic": fit_result.bic,
+        }
+        if cfg.get("return_train_states"):
+            result["train_states"] = fit_result.train_states
+        return result
+    except ValueError as err:
+        fallback_states = rules_fourier(train_df, test_df, cfg)
+        return {
+            "model": None,
+            "oos_states": fallback_states,
+            "train_summary": None,
+            "scaler": {"median": median, "mad": mad},
+            "fallback": "rules_fourier",
+            "reason": str(err),
+        }

--- a/test_regime_hmm.py
+++ b/test_regime_hmm.py
@@ -1,0 +1,148 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.regime_hmm import apply_hmm, fit_hmm, rules_fourier
+
+
+def _build_cluster(rng, loc, scale, size):
+    return rng.normal(loc, scale, size=(size, 2))
+
+
+def test_fit_hmm_rejects_rare_states():
+    rng = np.random.default_rng(42)
+    data = np.vstack([
+        _build_cluster(rng, loc=-4.0, scale=0.2, size=60),
+        _build_cluster(rng, loc=4.0, scale=0.2, size=60),
+        _build_cluster(rng, loc=0.0, scale=0.05, size=3),
+    ])
+    train_df = pd.DataFrame(data, columns=["f1", "f2"])
+    durations = pd.Series([1.0] * 120 + [1.0] * 3, index=train_df.index)
+    trades = pd.Series([5.0] * 120 + [1.0] * 3, index=train_df.index)
+
+    with pytest.raises(ValueError, match="rare states"):
+        fit_hmm(
+            train_df,
+            K=[3],
+            seed=0,
+            durations=durations,
+            trade_counts=trades,
+            min_duration_frac=0.05,
+            min_trade_frac=0.05,
+            min_trades=5.0,
+            min_obs=10,
+        )
+
+
+def test_apply_hmm_oos_prediction_without_lookahead():
+    rng = np.random.default_rng(0)
+    train_data = np.vstack([
+        _build_cluster(rng, loc=-1.0, scale=0.3, size=40),
+        _build_cluster(rng, loc=1.0, scale=0.3, size=40),
+    ])
+    test_data = np.vstack([
+        _build_cluster(rng, loc=-1.0, scale=0.25, size=10),
+        _build_cluster(rng, loc=1.0, scale=0.25, size=10),
+    ])
+
+    train_df = pd.DataFrame(train_data, columns=["feat1", "feat2"])
+    train_df["duration"] = 1.0
+    train_df["n_trades"] = 5.0
+    train_df["P1"] = np.linspace(100, 200, len(train_df))
+    train_df["LFP"] = np.linspace(0.6, 0.9, len(train_df))
+
+    test_df = pd.DataFrame(test_data, columns=["feat1", "feat2"])
+    test_df["duration"] = 1.0
+    test_df["n_trades"] = 5.0
+    test_df["P1"] = np.linspace(90, 210, len(test_df))
+    test_df["LFP"] = np.linspace(0.55, 0.95, len(test_df))
+
+    cfg = {
+        "feature_cols": ["feat1", "feat2"],
+        "duration_col": "duration",
+        "trade_count_col": "n_trades",
+        "K": [2],
+        "seed": 123,
+        "min_duration_frac": 0.01,
+        "min_trade_frac": 0.01,
+        "min_trades": 5.0,
+        "min_obs": 5,
+        "fourier_cols": {"P1": "P1", "LFP": "LFP"},
+        "return_train_states": True,
+    }
+
+    result = apply_hmm(train_df, test_df, cfg)
+    assert result["model"] is not None
+    assert len(result["oos_states"]) == len(test_df)
+    assert list(result["oos_states"].index) == list(test_df.index)
+
+    train_summary = result["train_summary"]
+    assert pytest.approx(train_summary["duration"].sum()) == train_df["duration"].sum()
+    assert pytest.approx(train_summary["trades"].sum()) == train_df["n_trades"].sum()
+    assert pytest.approx(train_summary["duration_frac"].sum()) == 1.0
+    assert pytest.approx(train_summary["trade_frac"].sum()) == 1.0
+
+    scaler = result["scaler"]
+    expected_median = train_df[["feat1", "feat2"]].median()
+    assert scaler["median"].equals(expected_median)
+
+    # The decoded training states are available for diagnostics only.
+    assert len(result["train_states"]) == len(train_df)
+
+
+def test_apply_hmm_fallback_rules_fourier():
+    rng = np.random.default_rng(1234)
+    train_values = np.vstack([
+        _build_cluster(rng, loc=-2.0, scale=0.2, size=30),
+        _build_cluster(rng, loc=2.0, scale=0.2, size=5),
+    ])
+    test_values = np.vstack([
+        _build_cluster(rng, loc=-2.0, scale=0.2, size=5),
+        _build_cluster(rng, loc=2.0, scale=0.2, size=5),
+    ])
+
+    train_df = pd.DataFrame(train_values, columns=["feat1", "feat2"])
+    train_df["duration"] = [2.0] * 30 + [0.1] * 5
+    train_df["n_trades"] = [10.0] * 30 + [0.5] * 5
+    train_df["P1"] = np.linspace(80, 160, len(train_df))
+    train_df["LFP"] = np.linspace(0.5, 0.95, len(train_df))
+
+    test_df = pd.DataFrame(test_values, columns=["feat1", "feat2"])
+    test_df["P1"] = np.linspace(70, 170, len(test_df))
+    test_df["LFP"] = np.linspace(0.45, 0.97, len(test_df))
+
+    cfg = {
+        "feature_cols": ["feat1", "feat2"],
+        "duration_col": "duration",
+        "trade_count_col": "n_trades",
+        "K": [3],
+        "seed": 7,
+        "min_duration_frac": 0.15,
+        "min_trade_frac": 0.15,
+        "min_trades": 6.0,
+        "min_obs": 10,
+        "fourier_cols": {"P1": "P1", "LFP": "LFP"},
+        "quantiles": (0.25, 0.75),
+    }
+
+    result = apply_hmm(train_df, test_df, cfg)
+    assert result["model"] is None
+    assert result["fallback"] == "rules_fourier"
+    assert "rare" in result["reason"].lower()
+
+    # Compute the expected Fourier-based regimes manually (train quantiles only).
+    p1_low, p1_high = train_df["P1"].quantile(0.25), train_df["P1"].quantile(0.75)
+    lfp_low, lfp_high = train_df["LFP"].quantile(0.25), train_df["LFP"].quantile(0.75)
+    expected_states = []
+    for _, row in test_df.iterrows():
+        if row["LFP"] >= lfp_high and row["P1"] >= p1_high:
+            expected_states.append("trend")
+        elif row["LFP"] <= lfp_low or row["P1"] <= p1_low:
+            expected_states.append("range")
+        else:
+            expected_states.append("transition")
+    assert list(result["oos_states"]) == expected_states
+
+    # Direct call to the fallback for completeness.
+    fallback_direct = rules_fourier(train_df, test_df, cfg)
+    pd.testing.assert_series_equal(result["oos_states"], fallback_direct)


### PR DESCRIPTION
## Summary
- add a regime_hmm module that fits Gaussian HMMs with duration/trade coverage safeguards and a Fourier fallback
- expose apply_hmm/predict_hmm utilities with docstrings that enforce frozen parameters for OOS inference
- cover the workflow with tests that ensure rare states are rejected and no lookahead occurs

## Testing
- pytest test_regime_hmm.py

------
https://chatgpt.com/codex/tasks/task_e_68cd52d9c8ac83318a69e3a38232dead