### PR TITLE
Add risk sizing helpers and integrate into backtest

### DIFF
--- a/src/backtest.py
+++ b/src/backtest.py
@@ -1,0 +1,195 @@
+"""Backtest engine integrating risk sizing helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+import numpy as np
+import pandas as pd
+
+from .risk_sizing import (
+    apply_funding_gating,
+    atr_mult_by_regime,
+    compute_atr,
+    position_size,
+)
+
+
+@dataclass(slots=True)
+class BacktestResult:
+    """Container holding the main backtest artefacts."""
+
+    equity_curve: pd.Series
+    position_history: pd.Series
+    max_drawdown: float
+    fees_paid: float
+    funding_paid: float
+    stopped_for_mdd: bool
+    net_equity: float
+    daily_stop_count: int
+
+
+REQUIRED_COLUMNS = {
+    "high",
+    "low",
+    "close",
+    "signal",
+    "return",
+    "fee_rate",
+    "funding_rate",
+}
+
+
+def run_backtest(
+    data: pd.DataFrame,
+    regime_labels: pd.Series | Mapping | None,
+    atr_period: int,
+    regime_cfg: Mapping,
+    *,
+    initial_equity: float = 1000.0,
+    cap_leverage: float = 1.0,
+    daily_loss_cap: float = 0.05,
+    funding_thresholds: Optional[Mapping[str, float]] = None,
+) -> BacktestResult:
+    """Execute a simplified backtest using ATR-based risk sizing.
+
+    Parameters
+    ----------
+    data:
+        OHLC dataframe with additional columns ``signal`` (direction), ``return``
+        (period return as decimal), ``fee_rate`` and ``funding_rate``.
+    regime_labels:
+        Regime classification aligned with ``data``. ``None`` means a constant
+        default multiplier.
+    atr_period:
+        Period used for ATR computation.
+    regime_cfg:
+        Mapping from regime labels to ATR multipliers, must include ``default``.
+    initial_equity:
+        Starting portfolio value.
+    cap_leverage:
+        Maximum leverage allowed when sizing positions.
+    daily_loss_cap:
+        Maximum tolerated loss for a single day expressed as a fraction of the
+        day's starting equity. ``0`` disables the guard-rail.
+    funding_thresholds:
+        Optional bounds used to gate exposure based on funding costs.
+    """
+    missing = REQUIRED_COLUMNS.difference(data.columns)
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise KeyError(f"data is missing required columns: {missing_str}")
+
+    df = data.copy()
+
+    atr = compute_atr(df, atr_period)
+
+    if regime_labels is None:
+        regime_series = pd.Series(["default"] * len(df), index=df.index)
+    elif isinstance(regime_labels, pd.Series):
+        regime_series = regime_labels.reindex(df.index)
+        regime_series = regime_series.ffill().bfill()
+        regime_series = regime_series.fillna("default")
+    else:
+        regime_series = pd.Series(list(regime_labels), index=df.index)
+
+    multipliers = atr_mult_by_regime(regime_series, regime_cfg)
+    funding_gate = apply_funding_gating(df["funding_rate"], funding_thresholds)
+
+    equity = float(initial_equity)
+    peak_equity = equity
+    prev_position = 0.0
+    mdd_stop = False
+    daily_stop_triggered = False
+    daily_stop_count = 0
+    fees_paid = 0.0
+    funding_paid = 0.0
+
+    prev_day = None
+    day_start_equity = equity
+    daily_loss = 0.0
+
+    equity_values: list[float] = []
+    position_values: list[float] = []
+
+    for idx, row in df.iterrows():
+        # Reset day-level guards
+        if isinstance(idx, pd.Timestamp):
+            current_day = idx.normalize()
+        else:
+            current_day = idx
+        if current_day != prev_day:
+            daily_loss = 0.0
+            daily_stop_triggered = False
+            day_start_equity = equity
+            prev_day = current_day
+
+        signal = float(row.get("signal", 0.0))
+        period_return = float(row.get("return", 0.0))
+        fee_rate = abs(float(row.get("fee_rate", 0.0)))
+        funding_rate = float(row.get("funding_rate", 0.0))
+        gate_allowed = bool(funding_gate.loc[idx] >= 0.5)
+
+        if not gate_allowed:
+            target_position = 0.0
+        elif mdd_stop or (daily_stop_triggered and signal != 0.0):
+            target_position = 0.0
+        else:
+            atr_value = float(atr.loc[idx])
+            mult = float(multipliers.loc[idx])
+            target_position = position_size(equity, atr_value, mult, cap_leverage)
+            target_position *= signal
+
+        pnl = prev_position * period_return
+        funding_cost = abs(prev_position) * funding_rate if gate_allowed else 0.0
+        position_change = target_position - prev_position
+        fee_cost = abs(position_change) * fee_rate
+
+        net_change = pnl - fee_cost - funding_cost
+
+        equity += net_change
+        fees_paid += fee_cost
+        funding_paid += funding_cost
+        daily_loss += net_change
+
+        equity_values.append(equity)
+        position_values.append(target_position)
+
+        prev_position = target_position
+
+        if equity > peak_equity:
+            peak_equity = equity
+
+        drawdown = 0.0
+        if peak_equity > 0:
+            drawdown = 1.0 - (equity / peak_equity)
+        if drawdown > 0.5:
+            mdd_stop = True
+            prev_position = 0.0
+            position_values[-1] = 0.0
+
+        if daily_loss_cap > 0 and not daily_stop_triggered:
+            loss_limit = -daily_loss_cap * day_start_equity
+            if daily_loss <= loss_limit:
+                daily_stop_triggered = True
+                daily_stop_count += 1
+                prev_position = 0.0
+                position_values[-1] = 0.0
+
+    equity_series = pd.Series(equity_values, index=df.index, dtype=float)
+    position_series = pd.Series(position_values, index=df.index, dtype=float)
+
+    running_max = equity_series.cummax()
+    drawdowns = 1.0 - equity_series / running_max.replace(0, np.nan)
+    max_drawdown = float(drawdowns.max(skipna=True) or 0.0)
+
+    return BacktestResult(
+        equity_curve=equity_series,
+        position_history=position_series,
+        max_drawdown=max_drawdown,
+        fees_paid=float(fees_paid),
+        funding_paid=float(funding_paid),
+        stopped_for_mdd=bool(mdd_stop),
+        net_equity=float(equity_series.iloc[-1]),
+        daily_stop_count=int(daily_stop_count),
+    )

--- a/src/risk_sizing.py
+++ b/src/risk_sizing.py
@@ -1,0 +1,129 @@
+"""Risk sizing helper utilities.
+
+This module centralises computations related to Average True Range (ATR),
+regime-specific leverage adjustments and funding guard-rails used by the
+backtest engine.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+def compute_atr(df: pd.DataFrame, period: int) -> pd.Series:
+    """Return the Average True Range (ATR) for *df*.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with at least ``high``, ``low`` and ``close`` columns.
+    period:
+        Averaging period used for the Wilder smoothing. Must be positive.
+
+    Returns
+    -------
+    pandas.Series
+        ATR values aligned with ``df``'s index.
+    """
+    if period <= 0:
+        raise ValueError("period must be strictly positive")
+
+    for col in ("high", "low", "close"):
+        if col not in df:
+            raise KeyError(f"Missing required column '{col}' for ATR computation")
+
+    high = pd.to_numeric(df["high"], errors="coerce")
+    low = pd.to_numeric(df["low"], errors="coerce")
+    close = pd.to_numeric(df["close"], errors="coerce")
+
+    prev_close = close.shift(1)
+    tr_components = pd.concat([
+        high - low,
+        (high - prev_close).abs(),
+        (low - prev_close).abs(),
+    ], axis=1)
+    true_range = tr_components.max(axis=1, skipna=True)
+
+    atr = true_range.ewm(alpha=1 / float(period), adjust=False).mean()
+    atr = atr.ffill()
+    return atr.fillna(0.0)
+
+
+def atr_mult_by_regime(labels: Sequence[Any] | pd.Series,
+                       cfg: Mapping[Any, float]) -> pd.Series:
+    """Map each regime label to an ATR multiplier.
+
+    ``cfg`` must provide a ``"default"`` entry used whenever a label is
+    missing from the mapping. The returned series is aligned with the input
+    order.
+    """
+    if "default" not in cfg:
+        raise KeyError("cfg must define a 'default' ATR multiplier")
+
+    if isinstance(labels, pd.Series):
+        index = labels.index
+        label_series = labels
+    else:
+        index = pd.RangeIndex(len(labels))
+        label_series = pd.Series(labels, index=index)
+
+    def _lookup(label: Any) -> float:
+        try:
+            mult = cfg[label]
+        except KeyError:
+            mult = cfg["default"]
+        if not np.isfinite(mult) or mult <= 0:
+            return float(cfg["default"])
+        return float(mult)
+
+    multipliers = label_series.map(_lookup).astype(float)
+    return multipliers.reindex(index)
+
+
+def position_size(equity: float, atr: float, mult: float,
+                  cap_leverage: float) -> float:
+    """Return position size scaled by ATR and leverage cap.
+
+    The function allocates notional ``equity * cap_leverage`` and scales it by
+    the volatility proxy ``atr * mult``. Invalid inputs return ``0.0``.
+    """
+    if (not np.isfinite(equity)) or equity <= 0:
+        return 0.0
+    if (not np.isfinite(atr)) or atr <= 0:
+        return 0.0
+    if (not np.isfinite(mult)) or mult <= 0:
+        return 0.0
+    if (not np.isfinite(cap_leverage)) or cap_leverage <= 0:
+        return 0.0
+
+    risk_unit = atr * mult
+    if risk_unit <= 0:
+        return 0.0
+
+    notional = equity * cap_leverage
+    return float(notional / risk_unit)
+
+
+def apply_funding_gating(funding_series: pd.Series,
+                         thresholds: Mapping[str, float] | None) -> pd.Series:
+    """Return a gating series (1.0 allowed, 0.0 blocked) based on funding.
+
+    Parameters
+    ----------
+    funding_series:
+        Series of funding rates/costs expressed per period.
+    thresholds:
+        Mapping that may define ``"min"`` and/or ``"max"`` tolerances. When
+        ``None`` the gate is always open.
+    """
+    if thresholds is None:
+        return pd.Series(1.0, index=funding_series.index, dtype=float)
+
+    lower = float(thresholds.get("min", -np.inf))
+    upper = float(thresholds.get("max", np.inf))
+
+    gating = ((funding_series >= lower) & (funding_series <= upper)).astype(float)
+    return gating.reindex(funding_series.index).fillna(0.0)

--- a/tests/test_risk_sizing.py
+++ b/tests/test_risk_sizing.py
@@ -1,0 +1,74 @@
+import pandas as pd
+import pytest
+
+from src.backtest import run_backtest
+
+
+def test_position_size_changes_with_regime():
+    index = pd.date_range("2023-01-01", periods=4, freq="D")
+    data = pd.DataFrame(
+        {
+            "high": [110, 111, 112, 113],
+            "low": [100, 101, 102, 103],
+            "close": [105, 106, 107, 108],
+            "signal": [1, 1, 1, 1],
+            "return": [0.0, 0.0, 0.0, 0.0],
+            "fee_rate": [0.0, 0.0, 0.0, 0.0],
+            "funding_rate": [0.0, 0.0, 0.0, 0.0],
+        },
+        index=index,
+    )
+    regimes = pd.Series(["bull", "bear", "bull", "bear"], index=index)
+    regime_cfg = {"default": 1.0, "bull": 1.0, "bear": 2.0}
+
+    result = run_backtest(
+        data,
+        regimes,
+        atr_period=3,
+        regime_cfg=regime_cfg,
+        initial_equity=10_000.0,
+        cap_leverage=1.0,
+        daily_loss_cap=0.05,
+    )
+
+    bull_positions = result.position_history[regimes == "bull"]
+    bear_positions = result.position_history[regimes == "bear"]
+
+    assert bull_positions.mean() > bear_positions.mean()
+    assert not bull_positions.eq(bear_positions.iloc[0]).all()
+
+
+def test_funding_costs_reduce_equity():
+    index = pd.date_range("2023-02-01", periods=3, freq="D")
+    data = pd.DataFrame(
+        {
+            "high": [101, 102, 103],
+            "low": [99, 100, 101],
+            "close": [100, 101, 102],
+            "signal": [1, 1, 1],
+            "return": [0.0, 0.0, 0.0],
+            "fee_rate": [0.0, 0.0, 0.0],
+            "funding_rate": [0.001, 0.001, 0.001],
+        },
+        index=index,
+    )
+    regimes = pd.Series(["neutral"] * len(index), index=index)
+    regime_cfg = {"default": 1.0, "neutral": 1.0}
+
+    result = run_backtest(
+        data,
+        regimes,
+        atr_period=2,
+        regime_cfg=regime_cfg,
+        initial_equity=1_000.0,
+        cap_leverage=1.0,
+        daily_loss_cap=0.0,
+    )
+
+    expected_funding = (
+        result.position_history.shift(1).fillna(0.0).abs() * data["funding_rate"]
+    ).sum()
+
+    assert result.funding_paid == pytest.approx(expected_funding)
+    assert result.net_equity == pytest.approx(1_000.0 - expected_funding)
+    assert result.funding_paid > 0


### PR DESCRIPTION
## Summary
- add reusable helpers to compute ATR, regime-specific multipliers, position sizing and funding gating
- create a backtest engine that applies the new sizing logic, caps drawdown at 50% and enforces daily loss/leverage guardrails
- cover the new behaviour with tests checking regime-based sizing and funding cost application

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd52e2e98c83319900fb6f4e307d19