### PR TITLE
Add walk-forward OOS evaluation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,23 @@ Licence
 Ce projet est distribué sous licence MIT — voir [LICENSE](LICENSE). Usage à des fins éducatives et expérimentales. Le trading comporte des risques.
 
 
+
+Walk-forward OOS (phase-aware)
+------------------------------
+Un pipeline complet est fourni pour lancer une analyse walk-forward annualisée (features Fourier + HMM + optimisation Ichimoku par phase) et comparer la stratégie phase-aware à la baseline 9-26-52-26.
+
+Commande minimale :
+
+```bash
+python run_oos.py --data path/to/BTC_USDT.csv --output outputs/wfa --seeds 0 1 2
+```
+
+Le script :
+
+- charge les données avec ``io_loader`` ;
+- calcule les features Fourier (``features_fourier``) ;
+- ajuste un HMM (``regime_hmm``) et optimise les paramètres par phase (``optimizer``) ;
+- applique le sizing simplifié (``risk_sizing``) ;
+- orchestre le walk-forward expanding (``wfa``) et agrège les métriques (``stats_eval``).
+
+Les métriques (Sharpe, Calmar, CAGR, MDD, moyenne mensuelle) sont exportées dans ``outputs/wfa`` avec comparatif Wilcoxon/Hodges–Lehmann contre la baseline. Des tests unitaires (``pytest``) valident le flux complet avec un dataset synthétique.

--- a/run_oos.py
+++ b/run_oos.py
@@ -1,0 +1,116 @@
+"""Run a full walk-forward (out-of-sample) evaluation.
+
+Example
+-------
+    python run_oos.py --data data/BTC_USDT_2h.csv --output outputs/wfa \
+        --seeds 0 1 2 --n-states 3 --n-trials 30
+
+The script glues together the IO helpers, Fourier feature extraction, HMM
+regime identification, parameter optimisation and statistics summarisation.
+All outputs (CSV and plots) are stored in the chosen output directory and are
+ready to be referenced from the README or research notes.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from src import features_fourier, io_loader, optimizer, regime_hmm, risk_sizing, stats_eval, wfa
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Walk-forward OOS evaluation")
+    parser.add_argument("--data", required=True, help="CSV OHLCV dataset (timestamp, open, high, low, close, volume)")
+    parser.add_argument("--output", default="outputs/wfa", help="Destination directory for reports")
+    parser.add_argument("--seeds", nargs="+", type=int, default=[0, 1, 2], help="Random seeds for the WFA loop")
+    parser.add_argument("--n-states", type=int, default=3, help="Number of HMM regimes")
+    parser.add_argument("--n-trials", type=int, default=25, help="Random-search trials per phase")
+    parser.add_argument("--feature-window", type=int, default=128, help="Rolling window used for Fourier features")
+    parser.add_argument("--lfp-cutoff", type=float, default=0.1, help="Low-frequency power cutoff (0-0.5)")
+    parser.add_argument("--min-train-years", type=int, default=1, help="Minimum number of in-sample years before scoring")
+    parser.add_argument("--min-train-size", type=int, default=200, help="Minimum number of samples in the training set")
+    parser.add_argument("--start-year", type=int, default=None, help="First year to include in the analysis")
+    parser.add_argument("--end-year", type=int, default=None, help="Last year to include in the analysis")
+    parser.add_argument(
+        "--baseline",
+        nargs=5,
+        type=float,
+        metavar=("TENKAN", "KIJUN", "SENKOU_B", "SHIFT", "ATR_MULT"),
+        help="Override baseline parameters (9 26 52 26 2.0)",
+    )
+    parser.add_argument(
+        "--periods-per-year",
+        type=int,
+        default=None,
+        help="Sampling frequency per year (auto-detected when omitted)",
+    )
+    return parser.parse_args(argv)
+
+
+def _make_config(args: argparse.Namespace, periods_per_year: int) -> wfa.WalkForwardConfig:
+    baseline = optimizer.BASELINE_PARAMS.copy()
+    if args.baseline is not None:
+        tenkan, kijun, senkou_b, shift, atr_mult = args.baseline
+        baseline = {
+            "tenkan": int(tenkan),
+            "kijun": int(kijun),
+            "senkou_b": int(senkou_b),
+            "shift": int(shift),
+            "atr_mult": float(atr_mult),
+        }
+    return wfa.WalkForwardConfig(
+        n_states=args.n_states,
+        n_trials=args.n_trials,
+        feature_window=args.feature_window,
+        lfp_cutoff=args.lfp_cutoff,
+        min_train_size=args.min_train_size,
+        min_train_years=args.min_train_years,
+        start_year=args.start_year,
+        end_year=args.end_year,
+        baseline_params=baseline,
+        periods_per_year=periods_per_year,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    data_path = Path(args.data)
+    df = io_loader.load_ohlcv_csv(data_path)
+    df = io_loader.ensure_ohlcv_dataframe(df)
+    periods_per_year = args.periods_per_year or io_loader.infer_periods_per_year(df.index)
+    config = _make_config(args, periods_per_year)
+    feature_cfg = features_fourier.FourierConfig(
+        window=args.feature_window, lfp_cutoff=args.lfp_cutoff, price_col="close"
+    )
+    hmm_cfg = regime_hmm.HMMConfig(n_states=args.n_states)
+    print(f"Fourier config: {feature_cfg}")
+    print(f"HMM config: {hmm_cfg}")
+    preview = risk_sizing.simulate_strategy(df.head(min(200, len(df))), config.baseline_params)
+    print(f"Baseline risk sizing preview: {preview.head(3).to_list()}")
+    result = wfa.run_walk_forward(df, args.seeds, config)
+    evaluation = stats_eval.evaluate_results(result.returns, periods_per_year, args.output)
+    summary = evaluation.summary
+    global_summary = summary[summary["phase"] == "global"]
+    if not global_summary.empty:
+        print("\nRésumé global (médiane / IQR):")
+        for _, row in global_summary.iterrows():
+            print(
+                f"- {row['strategy']} {row['metric']}: median={row['median']:.4f} "
+                f"iqr={row['iqr']:.4f} (n={int(row['count'])})"
+            )
+    else:
+        print("Aucun résultat disponible pour la synthèse globale.")
+    print(f"\nRapports sauvegardés dans: {Path(args.output).resolve()}")
+    if result.skipped_folds:
+        skipped_df = pd.DataFrame(result.skipped_folds)
+        skipped_path = Path(args.output) / "skipped_folds.csv"
+        skipped_df.to_csv(skipped_path, index=False)
+        print(f"Folds ignorés: {len(skipped_df)} (voir {skipped_path})")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,21 @@
+"""HSBC Ichimoku toolkit."""
+
+from . import (
+    features_fourier,
+    io_loader,
+    optimizer,
+    regime_hmm,
+    risk_sizing,
+    stats_eval,
+    wfa,
+)
+
+__all__ = [
+    "features_fourier",
+    "io_loader",
+    "optimizer",
+    "regime_hmm",
+    "risk_sizing",
+    "stats_eval",
+    "wfa",
+]

--- a/src/features_fourier.py
+++ b/src/features_fourier.py
@@ -1,0 +1,99 @@
+"""Fourier-based feature engineering utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(slots=True)
+class FourierConfig:
+    """Configuration holder used during feature extraction."""
+
+    window: int = 128
+    lfp_cutoff: float = 0.1
+    price_col: str = "close"
+
+
+def _periodogram(values: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return the frequencies and power spectral density for ``values``."""
+
+    x = np.asarray(values, dtype=float)
+    if np.all(np.isnan(x)):
+        return np.array([]), np.array([])
+    x = x - np.nanmean(x)
+    if np.allclose(x, 0.0):
+        return np.array([]), np.array([])
+    window = np.hanning(len(x))
+    x = np.where(np.isnan(x), 0.0, x) * window
+    fft = np.fft.rfft(x)
+    psd = (np.abs(fft) ** 2) / max(np.sum(window**2), 1e-12)
+    freqs = np.fft.rfftfreq(len(x), d=1.0)
+    return freqs, psd
+
+
+def _dominant_period(segment: np.ndarray) -> float:
+    freqs, psd = _periodogram(segment)
+    if len(freqs) <= 1:
+        return float("nan")
+    idx = int(np.argmax(psd[1:]) + 1)  # skip DC component
+    f_star = float(freqs[idx])
+    return float("nan") if f_star <= 0 else 1.0 / f_star
+
+
+def _low_frequency_ratio(segment: np.ndarray, cutoff: float) -> float:
+    freqs, psd = _periodogram(segment)
+    if len(freqs) == 0:
+        return float("nan")
+    mask = freqs <= cutoff
+    total = float(np.nansum(psd))
+    if total <= 0:
+        return float("nan")
+    return float(np.nansum(psd[mask]) / total)
+
+
+def compute_fourier_features(
+    df: pd.DataFrame,
+    config: FourierConfig | None = None,
+) -> pd.DataFrame:
+    """Compute Fourier features for ``df``.
+
+    The function returns a :class:`~pandas.DataFrame` containing, for each
+    timestamp, the dominant period estimate, the low-frequency power ratio, the
+    rolling volatility of log-returns and the raw log-return itself.
+    """
+
+    if config is None:
+        config = FourierConfig()
+    price = df[config.price_col].astype(float)
+    if not isinstance(price.index, pd.DatetimeIndex):
+        raise TypeError("L'index doit être temporel pour le calcul des features")
+
+    window = int(config.window)
+    if window <= 4:
+        raise ValueError("La fenêtre de Fourier doit être supérieure à 4")
+
+    dominant = np.full(len(price), np.nan, dtype=float)
+    lfp = np.full(len(price), np.nan, dtype=float)
+    values = price.values
+    for idx in range(window - 1, len(price)):
+        segment = values[idx - window + 1 : idx + 1]
+        dominant[idx] = _dominant_period(segment)
+        lfp[idx] = _low_frequency_ratio(segment, config.lfp_cutoff)
+
+    logret = np.log(price).diff()
+    vol = logret.rolling(window=min(window, max(5, window // 2))).std()
+    features = pd.DataFrame(
+        {
+            "dominant_period": dominant,
+            "lfp_ratio": lfp,
+            "log_return": logret,
+            "volatility": vol,
+        },
+        index=price.index,
+    )
+    return features
+
+
+__all__ = ["FourierConfig", "compute_fourier_features"]

--- a/src/io_loader.py
+++ b/src/io_loader.py
@@ -1,0 +1,127 @@
+"""Utility helpers for loading and validating OHLCV datasets.
+
+The functions in this module are intentionally lightweight so they can be
+reused both by scripts (``run_oos.py``) and unit tests.  They normalise the
+expected columns, ensure a :class:`~pandas.DatetimeIndex` and provide small
+helpers such as frequency inference.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+REQUIRED_COLUMNS: tuple[str, ...] = ("open", "high", "low", "close", "volume")
+
+
+def _normalise_columns(columns: Iterable[str]) -> list[str]:
+    """Return a list of lower-case column names stripped from surrounding
+    whitespace.
+    """
+
+    return [c.strip().lower() for c in columns]
+
+
+def _detect_timestamp_column(df: pd.DataFrame) -> str:
+    """Return the column containing timestamp information.
+
+    The loader accepts common aliases such as ``timestamp``, ``date`` or ``time``.
+    A :class:`ValueError` is raised when none can be found.
+    """
+
+    lowered = {c.lower(): c for c in df.columns}
+    for candidate in ("timestamp", "date", "time", "datetime"):
+        if candidate in lowered:
+            return lowered[candidate]
+    raise ValueError(
+        "Impossible de détecter la colonne temporelle (timestamp/date/time)."
+    )
+
+
+def load_ohlcv_csv(path: str | Path, tz: str | None = "UTC") -> pd.DataFrame:
+    """Load an OHLCV CSV file and return a validated DataFrame.
+
+    Parameters
+    ----------
+    path:
+        Location of the CSV file.  The file must contain at least the columns
+        defined in :data:`REQUIRED_COLUMNS` (case insensitive).
+    tz:
+        Optional timezone to localise the resulting index.
+    """
+
+    csv_path = Path(path)
+    if not csv_path.exists():  # pragma: no cover - defensive guard
+        raise FileNotFoundError(f"Fichier introuvable: {csv_path}")
+
+    df = pd.read_csv(csv_path)
+    if df.empty:
+        raise ValueError("Le fichier CSV est vide")
+
+    timestamp_col = _detect_timestamp_column(df)
+    df.columns = _normalise_columns(df.columns)
+    timestamp_series = pd.to_datetime(df[timestamp_col.lower()], utc=True)
+    if tz:
+        timestamp_series = timestamp_series.dt.tz_convert(tz)
+    df = df.drop(columns=[timestamp_col.lower()])
+
+    for column in REQUIRED_COLUMNS:
+        if column not in df.columns:
+            raise ValueError(
+                f"Colonne requise manquante dans le CSV: '{column}'"
+            )
+
+    df = df[list(REQUIRED_COLUMNS)]
+    df = df.apply(pd.to_numeric, errors="coerce")
+    df.index = pd.DatetimeIndex(timestamp_series, name="timestamp")
+    df = df.sort_index()
+    df = df.loc[~df.index.duplicated(keep="last")]
+    return df
+
+
+def ensure_ohlcv_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Validate a dataframe shape and columns.
+
+    The function simply checks for the mandatory OHLCV columns and that the
+    index is a :class:`~pandas.DatetimeIndex`.
+    """
+
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise TypeError("L'index doit être un DatetimeIndex")
+    missing = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing:
+        raise ValueError(f"Colonnes OHLCV manquantes: {missing}")
+    return df
+
+
+def infer_periods_per_year(index: pd.DatetimeIndex) -> int:
+    """Infer the number of periods per year from a datetime index.
+
+    The heuristic takes the median spacing between consecutive timestamps and
+    extrapolates it to a 365-day year.  Falling back to 252 when the index is
+    too short or irregular.
+    """
+
+    if len(index) < 2:
+        return 252
+    deltas = index.to_series().diff().dropna().dt.total_seconds()
+    median_delta = float(np.median(deltas)) if len(deltas) else 0.0
+    if median_delta <= 0.0:
+        return 252
+    seconds_per_year = 365.0 * 24.0 * 60.0 * 60.0
+    periods = int(round(seconds_per_year / median_delta))
+    return max(periods, 1)
+
+
+def restrict_years(df: pd.DataFrame, start_year: int | None, end_year: int | None) -> pd.DataFrame:
+    """Return a slice of ``df`` constrained to the inclusive year range."""
+
+    ensure_ohlcv_dataframe(df)
+    mask = pd.Series(True, index=df.index)
+    if start_year is not None:
+        mask &= df.index.year >= int(start_year)
+    if end_year is not None:
+        mask &= df.index.year <= int(end_year)
+    return df.loc[mask]

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -1,0 +1,105 @@
+"""Parameter search utilities for the phase-aware strategy."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+import numpy as np
+import pandas as pd
+
+from . import risk_sizing
+
+
+BASELINE_PARAMS: dict[str, float] = {
+    "tenkan": 9,
+    "kijun": 26,
+    "senkou_b": 52,
+    "shift": 26,
+    "atr_mult": 2.0,
+}
+
+
+@dataclass(slots=True)
+class OptimiserConfig:
+    n_trials: int = 25
+    seed: int | None = None
+
+
+def _sample_params(rng: np.random.Generator) -> dict[str, float]:
+    tenkan = int(rng.integers(5, 13))
+    kijun = int(rng.integers(max(tenkan + 5, 20), 80))
+    kijun = max(kijun, tenkan + 1)
+    senkou_b = int(rng.integers(max(kijun + 5, 40), 160))
+    shift = int(rng.integers(20, 35))
+    atr_mult = float(rng.uniform(1.0, 5.0))
+    return {
+        "tenkan": tenkan,
+        "kijun": kijun,
+        "senkou_b": senkou_b,
+        "shift": shift,
+        "atr_mult": atr_mult,
+    }
+
+
+def _sharpe_ratio(returns: pd.Series, periods_per_year: int = 252) -> float:
+    if returns.empty:
+        return float("nan")
+    mean = returns.mean()
+    std = returns.std(ddof=0)
+    if std <= 1e-12:
+        return float("nan")
+    return float(np.sqrt(periods_per_year) * mean / std)
+
+
+def optimise_phase_parameters(
+    df: pd.DataFrame,
+    phases: pd.Series,
+    config: OptimiserConfig,
+    periods_per_year: int,
+    baseline: dict[str, float] | None = None,
+) -> dict[str, dict[str, float]]:
+    """Random-search optimisation for each phase.
+
+    Parameters
+    ----------
+    df:
+        Training dataframe containing OHLCV data.
+    phases:
+        Phase labels aligned with ``df``.
+    config:
+        Optimiser configuration (number of trials and random seed).
+    periods_per_year:
+        Used for annualising the Sharpe ratio.
+    baseline:
+        Parameters used when a phase does not have enough observations.
+    """
+
+    if baseline is None:
+        baseline = BASELINE_PARAMS.copy()
+    rng = np.random.default_rng(config.seed)
+    params_by_phase: dict[str, dict[str, float]] = {}
+    valid_phases = [p for p in phases.dropna().unique()]
+    for phase in valid_phases:
+        mask = phases == phase
+        df_phase = df.loc[mask]
+        if len(df_phase) < 50:
+            params_by_phase[phase] = baseline.copy()
+            continue
+        best_score = -np.inf
+        best_params = baseline.copy()
+        for _ in range(int(config.n_trials)):
+            candidate = _sample_params(rng)
+            returns = risk_sizing.simulate_strategy(df_phase, candidate)
+            score = _sharpe_ratio(returns, periods_per_year)
+            if np.isnan(score):
+                continue
+            if score > best_score:
+                best_score = score
+                best_params = candidate
+        params_by_phase[phase] = best_params
+    if not params_by_phase:
+        params_by_phase["global"] = baseline.copy()
+    return params_by_phase
+
+
+__all__ = ["BASELINE_PARAMS", "OptimiserConfig", "optimise_phase_parameters"]

--- a/src/regime_hmm.py
+++ b/src/regime_hmm.py
@@ -1,0 +1,65 @@
+"""Hidden Markov Model helpers for phase/regime identification."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+from hmmlearn.hmm import GaussianHMM
+
+
+@dataclass(slots=True)
+class HMMConfig:
+    n_states: int = 3
+    covariance_type: str = "full"
+    n_iter: int = 200
+
+
+def _prepare_matrix(features: pd.DataFrame, columns: Iterable[str]) -> tuple[np.ndarray, pd.Index]:
+    matrix = features.loc[:, list(columns)].dropna()
+    return matrix.values, matrix.index
+
+
+def fit_regime_model(
+    features: pd.DataFrame,
+    config: HMMConfig | None = None,
+    random_state: int | None = None,
+) -> GaussianHMM:
+    """Fit a Gaussian HMM on the provided feature matrix."""
+
+    if config is None:
+        config = HMMConfig()
+    columns = ["dominant_period", "lfp_ratio", "volatility"]
+    X, _ = _prepare_matrix(features, columns)
+    if len(X) < config.n_states:
+        raise ValueError("Pas assez d'observations pour entraîner le HMM")
+    model = GaussianHMM(
+        n_components=int(config.n_states),
+        covariance_type=config.covariance_type,
+        n_iter=int(config.n_iter),
+        random_state=random_state,
+    )
+    model.fit(X)
+    return model
+
+
+def predict_regimes(
+    model: GaussianHMM,
+    features: pd.DataFrame,
+    columns: Iterable[str] | None = None,
+) -> pd.Series:
+    """Predict the hidden state sequence for ``features`` using ``model``."""
+
+    if columns is None:
+        columns = ("dominant_period", "lfp_ratio", "volatility")
+    X, idx = _prepare_matrix(features, columns)
+    if len(X) == 0:
+        return pd.Series(dtype=float, index=features.index)
+    states = model.predict(X)
+    series = pd.Series(np.nan, index=features.index, dtype=float)
+    series.loc[idx] = states
+    return series
+
+
+__all__ = ["HMMConfig", "fit_regime_model", "predict_regimes"]

--- a/src/risk_sizing.py
+++ b/src/risk_sizing.py
@@ -1,0 +1,53 @@
+"""Minimal risk sizing helpers used by the walk-forward engine."""
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+def simulate_strategy(df: pd.DataFrame, params: Dict[str, float]) -> pd.Series:
+    """Return a series of strategy returns under a simple Ichimoku-like rule."""
+
+    close = df["close"].astype(float)
+    tenkan = close.rolling(int(params["tenkan"]), min_periods=1).mean()
+    kijun = close.rolling(int(params["kijun"]), min_periods=1).mean()
+    signal = np.sign(tenkan - kijun)
+    lag = max(int(params.get("shift", 1)) // 2, 1)
+    signal = signal.shift(lag).fillna(0.0)
+    returns = close.pct_change().fillna(0.0)
+    scale = 1.0 / max(float(params.get("atr_mult", 1.0)), 1.0)
+    strategy_returns = signal * returns * scale
+    return strategy_returns
+
+
+def run_phase_strategy(
+    df: pd.DataFrame,
+    phases: pd.Series,
+    params_by_phase: Dict[str, Dict[str, float]],
+) -> tuple[pd.Series, dict[str, pd.Series]]:
+    """Simulate a phase-aware strategy.
+
+    Returns
+    -------
+    tuple
+        ``(global_returns, per_phase_returns)`` where ``per_phase_returns`` is a
+        mapping from phase label to a series aligned with ``df.index``.
+    """
+
+    global_returns = pd.Series(0.0, index=df.index, dtype=float)
+    per_phase: dict[str, pd.Series] = {}
+    for phase, params in params_by_phase.items():
+        mask = phases == phase
+        if not mask.any():
+            continue
+        df_phase = df.loc[mask]
+        phase_returns = simulate_strategy(df_phase, params)
+        phase_returns = phase_returns.reindex(df.index, fill_value=0.0)
+        per_phase[phase] = phase_returns
+        global_returns = global_returns.add(phase_returns, fill_value=0.0)
+    return global_returns, per_phase
+
+
+__all__ = ["simulate_strategy", "run_phase_strategy"]

--- a/src/stats_eval.py
+++ b/src/stats_eval.py
@@ -1,0 +1,227 @@
+"""Statistical evaluation helpers for walk-forward analysis."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.stats import wilcoxon
+
+METRIC_COLUMNS = ["sharpe", "calmar", "cagr", "mdd", "per_month"]
+
+
+@dataclass(slots=True)
+class EvaluationResult:
+    metrics: pd.DataFrame
+    metrics_long: pd.DataFrame
+    monthly_returns: pd.DataFrame
+    summary: pd.DataFrame
+    tests: pd.DataFrame
+
+
+def compute_metrics(returns: pd.Series, periods_per_year: int) -> dict[str, float]:
+    """Compute Sharpe, Calmar, CAGR, MDD and mean monthly return."""
+
+    if returns is None or len(returns) == 0:
+        return {metric: float("nan") for metric in METRIC_COLUMNS}
+    returns = returns.dropna()
+    if returns.empty:
+        return {metric: float("nan") for metric in METRIC_COLUMNS}
+    mean = returns.mean()
+    std = returns.std(ddof=0)
+    sharpe = float(np.sqrt(periods_per_year) * mean / std) if std > 0 else float("nan")
+    equity = (1.0 + returns).cumprod()
+    final = equity.iloc[-1]
+    periods = len(returns)
+    years = periods / float(periods_per_year) if periods_per_year > 0 else float("nan")
+    if final <= 0 or years <= 0:
+        cagr = float("nan")
+    else:
+        cagr = float(final ** (1.0 / years) - 1.0)
+    peak = equity.cummax()
+    drawdown = equity / peak - 1.0
+    mdd = float(drawdown.min()) if not drawdown.empty else float("nan")
+    calmar = float(cagr / abs(mdd)) if mdd < 0 and np.isfinite(cagr) else float("nan")
+    if isinstance(returns.index, pd.DatetimeIndex):
+        monthly = (1.0 + returns).resample("M").prod() - 1.0
+        per_month = float(monthly.mean()) if not monthly.empty else float("nan")
+    else:
+        per_month = float("nan")
+    return {
+        "sharpe": sharpe,
+        "calmar": calmar,
+        "cagr": cagr,
+        "mdd": mdd,
+        "per_month": per_month,
+    }
+
+
+def compute_monthly_returns(returns: pd.Series) -> pd.Series:
+    if not isinstance(returns.index, pd.DatetimeIndex):
+        return pd.Series(dtype=float)
+    monthly = (1.0 + returns).resample("M").prod() - 1.0
+    monthly.index = monthly.index.to_period("M").to_timestamp("M")
+    return monthly
+
+
+def _hodges_lehmann(x: np.ndarray, y: np.ndarray) -> float:
+    diff = np.asarray(x) - np.asarray(y)
+    if diff.size == 0:
+        return float("nan")
+    return float(np.median(diff))
+
+
+def build_metrics_table(returns: pd.DataFrame, periods_per_year: int) -> tuple[pd.DataFrame, pd.DataFrame]:
+    records: list[dict[str, object]] = []
+    monthly_records: list[dict[str, object]] = []
+    for (strategy, seed, phase), group in returns.groupby(["strategy", "seed", "phase"]):
+        series = group.sort_values("timestamp").set_index("timestamp")["return"].astype(float)
+        metrics = compute_metrics(series, periods_per_year)
+        record = {"strategy": strategy, "seed": seed, "phase": phase}
+        record.update(metrics)
+        records.append(record)
+        monthly = compute_monthly_returns(series)
+        for ts, value in monthly.items():
+            monthly_records.append(
+                {
+                    "strategy": strategy,
+                    "seed": seed,
+                    "phase": phase,
+                    "month": ts,
+                    "return": float(value),
+                }
+            )
+    for (strategy, seed), group in returns.groupby(["strategy", "seed"]):
+        series = group.sort_values("timestamp").set_index("timestamp")["return"].astype(float)
+        metrics = compute_metrics(series, periods_per_year)
+        record = {"strategy": strategy, "seed": seed, "phase": "global"}
+        record.update(metrics)
+        records.append(record)
+        monthly = compute_monthly_returns(series)
+        for ts, value in monthly.items():
+            monthly_records.append(
+                {
+                    "strategy": strategy,
+                    "seed": seed,
+                    "phase": "global",
+                    "month": ts,
+                    "return": float(value),
+                }
+            )
+    metrics_df = pd.DataFrame.from_records(records)
+    monthly_df = pd.DataFrame.from_records(monthly_records)
+    return metrics_df, monthly_df
+
+
+def aggregate_metrics(metrics_long: pd.DataFrame) -> pd.DataFrame:
+    summary = (
+        metrics_long.groupby(["strategy", "phase", "metric"])  # type: ignore[arg-type]
+        .agg(
+            median=("value", "median"),
+            q1=("value", lambda x: x.quantile(0.25)),
+            q3=("value", lambda x: x.quantile(0.75)),
+            iqr=("value", lambda x: x.quantile(0.75) - x.quantile(0.25)),
+            count=("value", "count"),
+        )
+        .reset_index()
+    )
+    return summary
+
+
+def compare_strategies(metrics_long: pd.DataFrame, phase: str = "global") -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    strategies = metrics_long["strategy"].unique()
+    if "phaseaware" not in strategies or "baseline" not in strategies:
+        return pd.DataFrame(columns=["metric", "wilcoxon_stat", "wilcoxon_pvalue", "hodges_lehmann", "n"])
+    for metric in METRIC_COLUMNS:
+        pa = metrics_long[
+            (metrics_long["strategy"] == "phaseaware")
+            & (metrics_long["phase"] == phase)
+            & (metrics_long["metric"] == metric)
+        ]
+        bl = metrics_long[
+            (metrics_long["strategy"] == "baseline")
+            & (metrics_long["phase"] == phase)
+            & (metrics_long["metric"] == metric)
+        ]
+        merged = pa.merge(bl, on="seed", suffixes=("_pa", "_bl"))
+        if merged.empty:
+            continue
+        stat, pvalue = wilcoxon(merged["value_pa"], merged["value_bl"], zero_method="wilcox")
+        hl = _hodges_lehmann(merged["value_pa"].to_numpy(), merged["value_bl"].to_numpy())
+        rows.append(
+            {
+                "metric": metric,
+                "wilcoxon_stat": float(stat),
+                "wilcoxon_pvalue": float(pvalue),
+                "hodges_lehmann": hl,
+                "n": int(len(merged)),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _plot_boxplots(metrics_long: pd.DataFrame, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    global_metrics = metrics_long[metrics_long["phase"] == "global"]
+    for metric in METRIC_COLUMNS:
+        subset = global_metrics[global_metrics["metric"] == metric]
+        if subset.empty:
+            continue
+        data = [
+            subset.loc[subset["strategy"] == strategy, "value"].dropna().to_numpy()
+            for strategy in ["phaseaware", "baseline"]
+        ]
+        labels = ["phaseaware", "baseline"]
+        plt.figure(figsize=(6, 4))
+        plt.boxplot(data, labels=labels, notch=True)
+        plt.title(f"Distribution {metric} (global)")
+        plt.tight_layout()
+        plt.savefig(output_dir / f"boxplot_{metric}.png", dpi=150)
+        plt.close()
+
+
+def evaluate_results(
+    returns: pd.DataFrame,
+    periods_per_year: int,
+    output_dir: str | Path,
+) -> EvaluationResult:
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    metrics_df, monthly_df = build_metrics_table(returns, periods_per_year)
+    metrics_long = metrics_df.melt(
+        id_vars=["strategy", "seed", "phase"],
+        value_vars=[col for col in METRIC_COLUMNS if col in metrics_df.columns],
+        var_name="metric",
+        value_name="value",
+    )
+    summary_df = aggregate_metrics(metrics_long)
+    tests_df = compare_strategies(metrics_long)
+    metrics_df.to_csv(output_path / "metrics_by_seed.csv", index=False)
+    metrics_long.to_csv(output_path / "metrics_long.csv", index=False)
+    summary_df.to_csv(output_path / "summary_median_iqr.csv", index=False)
+    tests_df.to_csv(output_path / "wilcoxon_comparison.csv", index=False)
+    monthly_df.to_csv(output_path / "monthly_returns.csv", index=False)
+    _plot_boxplots(metrics_long, output_path)
+    return EvaluationResult(
+        metrics=metrics_df,
+        metrics_long=metrics_long,
+        monthly_returns=monthly_df,
+        summary=summary_df,
+        tests=tests_df,
+    )
+
+
+__all__ = [
+    "EvaluationResult",
+    "compute_metrics",
+    "compute_monthly_returns",
+    "build_metrics_table",
+    "aggregate_metrics",
+    "compare_strategies",
+    "evaluate_results",
+]

--- a/src/wfa.py
+++ b/src/wfa.py
@@ -1,0 +1,222 @@
+"""Walk-forward analysis orchestrator."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+from . import features_fourier, optimizer, regime_hmm, risk_sizing, stats_eval
+
+
+@dataclass(slots=True)
+class WalkForwardConfig:
+    n_states: int = 3
+    n_trials: int = 25
+    feature_window: int = 128
+    lfp_cutoff: float = 0.1
+    min_train_size: int = 200
+    min_train_years: int = 1
+    start_year: int | None = None
+    end_year: int | None = None
+    baseline_params: dict[str, float] = field(
+        default_factory=lambda: optimizer.BASELINE_PARAMS.copy()
+    )
+    periods_per_year: int = 252
+
+
+@dataclass(slots=True)
+class WFAResult:
+    returns: pd.DataFrame
+    metrics: pd.DataFrame
+    params: pd.DataFrame
+    skipped_folds: list[dict[str, object]]
+    config: WalkForwardConfig
+
+
+def _prepare_phases(series: pd.Series) -> pd.Series:
+    mapped = series.copy()
+    mapped = mapped.map(lambda x: f"phase_{int(x)}" if pd.notna(x) else np.nan)
+    return mapped.astype("object")
+
+
+def _complete_params(
+    params_by_phase: dict[str, dict[str, float]],
+    phases: Iterable[str],
+    baseline: dict[str, float],
+) -> dict[str, dict[str, float]]:
+    completed = {phase: params.copy() for phase, params in params_by_phase.items()}
+    for phase in set(phases):
+        if phase is None or (isinstance(phase, float) and np.isnan(phase)):
+            continue
+        if phase not in completed:
+            completed[phase] = baseline.copy()
+    return completed
+
+
+def run_walk_forward(
+    df: pd.DataFrame,
+    seeds: Sequence[int],
+    config: WalkForwardConfig,
+) -> WFAResult:
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise TypeError("L'index doit être de type DatetimeIndex")
+    df = df.sort_index()
+    features = features_fourier.compute_fourier_features(
+        df,
+        features_fourier.FourierConfig(
+            window=config.feature_window,
+            lfp_cutoff=config.lfp_cutoff,
+            price_col="close",
+        ),
+    )
+    years = sorted(df.index.year.unique())
+    if config.start_year is not None:
+        years = [y for y in years if y >= config.start_year]
+    if config.end_year is not None:
+        years = [y for y in years if y <= config.end_year]
+    if len(years) <= config.min_train_years:
+        raise ValueError("Pas assez d'années pour exécuter le walk-forward")
+
+    all_returns: list[pd.DataFrame] = []
+    all_metrics: list[dict[str, object]] = []
+    params_records: list[dict[str, object]] = []
+    skipped: list[dict[str, object]] = []
+
+    for seed in seeds:
+        hmm_cfg = regime_hmm.HMMConfig(n_states=config.n_states)
+        opt_cfg = optimizer.OptimiserConfig(n_trials=config.n_trials, seed=seed)
+        for idx in range(config.min_train_years, len(years)):
+            test_year = years[idx]
+            train_years = years[:idx]
+            train_df = df[df.index.year.isin(train_years)]
+            if len(train_df) < config.min_train_size:
+                skipped.append({"seed": seed, "year": test_year, "reason": "train_size"})
+                continue
+            test_df = df[df.index.year == test_year]
+            train_features = features.loc[train_df.index]
+            try:
+                model = regime_hmm.fit_regime_model(train_features, hmm_cfg, random_state=seed)
+            except ValueError:
+                skipped.append({"seed": seed, "year": test_year, "reason": "hmm_fit"})
+                continue
+            train_states = regime_hmm.predict_regimes(model, train_features)
+            train_phases = _prepare_phases(train_states)
+            test_features = features.loc[test_df.index]
+            test_states = regime_hmm.predict_regimes(model, test_features)
+            test_phases = _prepare_phases(test_states)
+            if test_phases.isna().all():
+                skipped.append({"seed": seed, "year": test_year, "reason": "no_phases"})
+                continue
+            test_phases = test_phases.fillna(method="ffill").fillna(method="bfill").fillna("phase_unknown")
+            params_by_phase = optimizer.optimise_phase_parameters(
+                train_df,
+                train_phases,
+                opt_cfg,
+                config.periods_per_year,
+                config.baseline_params,
+            )
+            params_by_phase = _complete_params(
+                params_by_phase,
+                test_phases.unique(),
+                config.baseline_params,
+            )
+            global_returns, per_phase_returns = risk_sizing.run_phase_strategy(
+                test_df,
+                test_phases,
+                params_by_phase,
+            )
+            baseline_returns = risk_sizing.simulate_strategy(test_df, config.baseline_params)
+            records = pd.DataFrame(
+                {
+                    "timestamp": test_df.index,
+                    "return": global_returns.values,
+                    "seed": seed,
+                    "year": test_year,
+                    "strategy": "phaseaware",
+                    "phase": test_phases.values,
+                }
+            )
+            baseline_records = pd.DataFrame(
+                {
+                    "timestamp": test_df.index,
+                    "return": baseline_returns.values,
+                    "seed": seed,
+                    "year": test_year,
+                    "strategy": "baseline",
+                    "phase": test_phases.values,
+                }
+            )
+            all_returns.extend([records, baseline_records])
+            for phase, params in params_by_phase.items():
+                params_record = {
+                    "seed": seed,
+                    "year": test_year,
+                    "phase": phase,
+                    **params,
+                }
+                params_records.append(params_record)
+            metrics_phaseaware = stats_eval.compute_metrics(
+                global_returns, config.periods_per_year
+            )
+            metrics_phaseaware.update(
+                {
+                    "strategy": "phaseaware",
+                    "seed": seed,
+                    "phase": "global",
+                    "year": test_year,
+                }
+            )
+            all_metrics.append(metrics_phaseaware)
+            baseline_metrics = stats_eval.compute_metrics(
+                baseline_returns, config.periods_per_year
+            )
+            baseline_metrics.update(
+                {
+                    "strategy": "baseline",
+                    "seed": seed,
+                    "phase": "global",
+                    "year": test_year,
+                }
+            )
+            all_metrics.append(baseline_metrics)
+            for phase, returns in per_phase_returns.items():
+                metrics = stats_eval.compute_metrics(
+                    returns.loc[test_df.index], config.periods_per_year
+                )
+                metrics.update(
+                    {
+                        "strategy": "phaseaware",
+                        "seed": seed,
+                        "phase": phase,
+                        "year": test_year,
+                    }
+                )
+                all_metrics.append(metrics)
+            for phase in test_phases.unique():
+                mask = test_phases == phase
+                returns = baseline_returns.loc[mask]
+                metrics = stats_eval.compute_metrics(returns, config.periods_per_year)
+                metrics.update(
+                    {
+                        "strategy": "baseline",
+                        "seed": seed,
+                        "phase": phase,
+                        "year": test_year,
+                    }
+                )
+                all_metrics.append(metrics)
+    returns_df = pd.concat(all_returns, ignore_index=True) if all_returns else pd.DataFrame()
+    metrics_df = pd.DataFrame.from_records(all_metrics)
+    params_df = pd.DataFrame.from_records(params_records)
+    return WFAResult(
+        returns=returns_df,
+        metrics=metrics_df,
+        params=params_df,
+        skipped_folds=skipped,
+        config=config,
+    )
+
+
+__all__ = ["WalkForwardConfig", "WFAResult", "run_walk_forward"]

--- a/tests/test_wfa_pipeline.py
+++ b/tests/test_wfa_pipeline.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from src import io_loader, stats_eval, wfa
+import run_oos
+
+
+def _make_mock_dataset() -> pd.DataFrame:
+    rng = np.random.default_rng(42)
+    index = pd.date_range("2018-01-01", "2023-12-31", freq="D")
+    base = 100 + rng.standard_normal(len(index)).cumsum()
+    high = base + rng.uniform(0.1, 1.0, size=len(index))
+    low = base - rng.uniform(0.1, 1.0, size=len(index))
+    open_ = base + rng.normal(0, 0.2, size=len(index))
+    close = base
+    volume = rng.uniform(100, 200, size=len(index))
+    df = pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volume,
+        },
+        index=index,
+    )
+    df.index.name = "timestamp"
+    return df
+
+
+def test_walk_forward_pipeline(tmp_path: Path) -> None:
+    df = _make_mock_dataset()
+    csv_path = tmp_path / "mock.csv"
+    df.reset_index().to_csv(csv_path, index=False)
+    loaded = io_loader.load_ohlcv_csv(csv_path)
+    config = wfa.WalkForwardConfig(
+        n_states=2,
+        n_trials=5,
+        feature_window=32,
+        lfp_cutoff=0.2,
+        min_train_size=200,
+        min_train_years=1,
+        periods_per_year=365,
+    )
+    result = wfa.run_walk_forward(loaded, seeds=[0, 1], config=config)
+    assert not result.returns.empty
+    assert {"phaseaware", "baseline"} <= set(result.returns["strategy"].unique())
+    reports_dir = tmp_path / "reports"
+    evaluation = stats_eval.evaluate_results(result.returns, 365, reports_dir)
+    assert (reports_dir / "metrics_by_seed.csv").exists()
+    assert not evaluation.summary.empty
+    assert (evaluation.tests.empty or set(evaluation.tests["metric"]).issubset(stats_eval.METRIC_COLUMNS))
+
+
+def test_run_oos_main(tmp_path: Path) -> None:
+    df = _make_mock_dataset()
+    csv_path = tmp_path / "mock.csv"
+    df.reset_index().to_csv(csv_path, index=False)
+    out_dir = tmp_path / "out"
+    args = [
+        "--data",
+        str(csv_path),
+        "--output",
+        str(out_dir),
+        "--seeds",
+        "0",
+        "1",
+        "--n-states",
+        "2",
+        "--n-trials",
+        "5",
+        "--feature-window",
+        "32",
+        "--lfp-cutoff",
+        "0.2",
+        "--periods-per-year",
+        "365",
+        "--start-year",
+        "2019",
+        "--end-year",
+        "2022",
+    ]
+    exit_code = run_oos.main(args)
+    assert exit_code == 0
+    assert (out_dir / "wilcoxon_comparison.csv").exists()


### PR DESCRIPTION
## Summary
- implement IO, Fourier, regime, optimisation and risk sizing helpers along with the walk-forward orchestrator
- add statistical evaluation utilities and a README-ready `run_oos.py` CLI to produce metrics/plots
- cover the new workflow with synthetic dataset tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd52eaeda4833186624c47e41aa3e9