### PR TITLE
Normalize monthly returns before period conversion

### DIFF
--- a/src/stats_eval.py
+++ b/src/stats_eval.py
@@ -66,8 +66,13 @@ def compute_monthly_returns(returns: pd.Series) -> pd.Series:
     if not isinstance(returns.index, pd.DatetimeIndex):
         return pd.Series(dtype=float)
     monthly = (1.0 + returns).resample("ME").prod() - 1.0
-    if not monthly.empty:
+    if monthly.empty:
+        return monthly
+    if monthly.index.tz is not None:
+        monthly.index = monthly.index.tz_convert(None).tz_localize(None)
+    else:
         monthly.index = monthly.index.tz_localize(None)
+    monthly.index = monthly.index.to_period("M")
     return monthly
 
 

--- a/tests/test_stats_eval.py
+++ b/tests/test_stats_eval.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pandas as pd
+import pandas.testing as tm
+
+from src import stats_eval
+
+
+def _build_returns(tz: str | None = None) -> pd.Series:
+    index = pd.DatetimeIndex(
+        [
+            "2021-01-10",
+            "2021-01-20",
+            "2021-02-10",
+            "2021-02-20",
+        ],
+        tz=tz,
+    )
+    return pd.Series([0.01, 0.02, 0.03, 0.04], index=index, dtype=float)
+
+
+def _expected_monthly_returns() -> pd.Series:
+    expected_index = pd.period_range("2021-01", "2021-02", freq="M")
+    expected_values = [
+        (1.01 * 1.02) - 1.0,
+        (1.03 * 1.04) - 1.0,
+    ]
+    return pd.Series(expected_values, index=expected_index, dtype=float)
+
+
+def test_compute_monthly_returns_with_naive_index() -> None:
+    returns = _build_returns()
+    monthly = stats_eval.compute_monthly_returns(returns)
+    expected = _expected_monthly_returns()
+    assert isinstance(monthly.index, pd.PeriodIndex)
+    tm.assert_index_equal(monthly.index, expected.index)
+    tm.assert_series_equal(monthly, expected, rtol=1e-9, atol=0.0)
+
+
+def test_compute_monthly_returns_with_timezone_aware_index() -> None:
+    returns = _build_returns("UTC")
+    monthly = stats_eval.compute_monthly_returns(returns)
+    expected = _expected_monthly_returns()
+    assert isinstance(monthly.index, pd.PeriodIndex)
+    tm.assert_index_equal(monthly.index, expected.index)
+    tm.assert_series_equal(monthly, expected, rtol=1e-9, atol=0.0)


### PR DESCRIPTION
## Summary
- drop timezone information from resampled monthly return indices before converting them to periods
- cover timezone-aware and naive indices in `compute_monthly_returns` with dedicated unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ce8b401f20833183c9280ebc3178a0